### PR TITLE
Reduce user confusion about input format

### DIFF
--- a/activity_report/activity_report.ini.sample
+++ b/activity_report/activity_report.ini.sample
@@ -1,4 +1,4 @@
 [activity_report]
 tasks = 
-start_time = 
-end_time = 
+start_time = mm-dd-YYYY HH:MM:SS
+end_time = mm-dd-YYYY HH:MM:SS


### PR DESCRIPTION
Updates `activity_report/activity_report.ini.sample` to contain a default value of `mm-dd-YYYY HH:MM:SS` to reduce user confusion about input format.